### PR TITLE
Use more generic shebangs and mark executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Start scrapping, list of application will be write in app_ids.txt
 
 **You can use it without any option it will take the default config inside config.sh :**
 ```
-#!/bin/bash
+#!/usr/bin/env bash
 APP_ID='app_ids.txt'
 APP_TESTED='app_ids_tested.txt'
 

--- a/config.sh
+++ b/config.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 APP_ID='app_ids.txt'
 APP_TESTED='app_ids_tested.txt'
 

--- a/hunt.sh
+++ b/hunt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source config.sh
 

--- a/scrapping-playstore.sh
+++ b/scrapping-playstore.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VERBOSE='FALSE'
 RECURSIVE='FALSE'

--- a/sort-report.sh
+++ b/sort-report.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 APP_RESULT='APP_RESULT/'
 SORT_RESULT='SORT_RESULT'


### PR DESCRIPTION
Thank you for this project.

Currently the project makes the hypothesis that the user is running a GNU/Linux distribution that puts `bash` in `/bin/bash` (following this standard: https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard).

However this is not generic enough to make these scripts work on NixOS or other operating systems where `bash` is elsewhere.
This pull request proposes to use the more generic `/usr/bin/env bash`. It also marks files as executable in git tree.